### PR TITLE
Fixed bug #91235; now works with Moose 2.1204

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -9,10 +9,7 @@ lib/MooseX/Getopt/Usage.pm
 lib/MooseX/Getopt/Usage/Formatter.pm
 lib/MooseX/Getopt/Usage/Pod/Text.pm
 lib/MooseX/Getopt/Usage/Role/Man.pm
-Makefile.PL
 MANIFEST
-META.json
-META.yml
 README
 t/00-load.t
 t/basic.t

--- a/lib/MooseX/Getopt/Usage/Formatter.pm
+++ b/lib/MooseX/Getopt/Usage/Formatter.pm
@@ -1,7 +1,7 @@
 package MooseX::Getopt::Usage::Formatter;
 
 use 5.010;
-our $VERSION = '0.18';
+our $VERSION = '0.19';
 
 use Moose;
 #use MooseX::StrictConstructor;
@@ -63,17 +63,17 @@ has pod_file => (
 );
 
 sub _build_pod_file {
+
     my $self = shift;
+
     my $gclass = $self->getopt_class;
-    if ( is_loaded($gclass) ) {
-        return pod_where( {-inc => 1}, $gclass );
-    }
-    else {
-        # Class doesn't seem to be loaded (used) so try the script file. E.g. a
-        # class definition and main pkg runner all in one file.
-        my $file = "$FindBin::Bin/$FindBin::Script";
-        return $file if -f $file && contains_pod($file);
-    }
+
+    my $file = "$FindBin::Bin/$FindBin::Script";
+
+    return $file if -f $file && contains_pod($file);
+
+    return pod_where( {-inc => 1}, $gclass ) if is_loaded($gclass);
+
     return undef;
 }
 


### PR DESCRIPTION
Hi Mark,

Version 0.18 fails to install without force. Several tests fail during `Build test`:

https://rt.cpan.org/Public/Bug/Display.html?id=91235

I've identified the problem and have added a fix. Updated to version 0.19. Would you mind pushing this out to CPAN?Thanks.
