### PR TITLE
Fix coloring of multi-word options.

### DIFF
--- a/lib/MooseX/Getopt/Usage/Formatter.pm
+++ b/lib/MooseX/Getopt/Usage/Formatter.pm
@@ -474,7 +474,7 @@ sub _colourise {
     my $colours = $self->colours;
 
     my $str = ref $out ? $out : \$out;
-    $$str =~ s/(^|\s|\[)(--?[\w?]+)/"$1".colored $colours->{flag},"$2"/ge;
+    $$str =~ s/(^|\s|\[)(--?[\w?\-]+)/"$1".colored $colours->{flag},"$2"/ge;
     return ref $out ? $out : $$str;
 }
 


### PR DESCRIPTION
If you have a multi-word option such as:

 has foo_bar => (is => 'ro', metaclass => 'Getopt', cmd_flag => 'get-opt');

Then this is handled with the getopt options `--foo-bar`

The colorized output only colors `--foo` and the `-bar` is uncolored
because the formatter stops at the first non-word character.

Given that `-` is a common word separator for multi-word options, it
makes sense to include this in the list of chars that are colored.